### PR TITLE
Use f-strings

### DIFF
--- a/fuzzerest/cli.py
+++ b/fuzzerest/cli.py
@@ -155,7 +155,7 @@ class Client:
         for token in sys.argv:
             try:
                 if isinstance(json.loads(token), (dict, list)):
-                    cmd += " '{0}'".format(token)
+                    cmd += f" '{token}'"
                 else:
                     cmd += " " + token
             except (json.decoder.JSONDecodeError, TypeError):

--- a/fuzzerest/fuzzer.py
+++ b/fuzzerest/fuzzer.py
@@ -19,7 +19,7 @@ from fuzzerest.config.config import Config
 class Fuzzer:
     def log_last_state_used(self, state):
         self.config.root_logger.log(
-            self.config.note_log_level, "Last state used: {0}".format(state)
+            self.config.note_log_level, "Last state used: %s", state
         )
 
     def _send_slack_message(self, message):
@@ -29,7 +29,7 @@ class Fuzzer:
 
     def exit_handler(self, signum, frame):
         self.config.root_logger.log(
-            self.config.note_log_level, "Exited with signal: {0}".format(signum)
+            self.config.note_log_level, "Exited with signal: %s", signum
         )
         if signum != 0:
             self.config.root_logger.log(logging.ERROR, traceback.extract_stack(frame))
@@ -94,16 +94,12 @@ class Fuzzer:
             self.methods = []
             for m in methods:
                 if m not in request.METHODS:
-                    raise RuntimeError(
-                        "method {0} is not a valid HTTP method".format(str(m))
-                    )
+                    raise RuntimeError(f"method {m} is not a valid HTTP method")
                 self.methods.append(m.upper())
         elif isinstance(methods, str) and methods in request.METHODS:
             self.methods = [methods]
         else:
-            raise RuntimeError(
-                "method {0} is not a valid HTTP method".format(str(methods))
-            )
+            raise RuntimeError(f"method {methods} is not a valid HTTP method")
 
         name = "-" + os.path.splitext(os.path.basename(self.model_file_path))[0]
         name += (
@@ -115,7 +111,7 @@ class Fuzzer:
             else "_" + "_".join(self.methods)
         )
         self.log_file_name = os.path.join(
-            self.config.results_dir, "{0}{1}.log".format(strftime("%Y%m%d%H%M%S"), name)
+            self.config.results_dir, f'{strftime("%Y%m%d%H%M%S")}{name}.log'
         )
         file_handler = logging.FileHandler(self.log_file_name)
         file_handler.setFormatter(self.config.log_formatter)
@@ -266,9 +262,7 @@ class Fuzzer:
 
         if not endpoints:
             raise RuntimeError(
-                "failed to locate uri '{0}' with method '{1}' in model".format(
-                    self.uri, method
-                )
+                f'failed to locate uri "{self.uri}" with method "{method}" in model'
             )
 
         endpoint_obj = self.inject_constants(endpoints[0], self.constants)
@@ -406,11 +400,15 @@ class Fuzzer:
                 if my_timeout is not None:
                     self.config.root_logger.log(
                         self.config.trace_log_level,
-                        "timeout={0}s delay={1}s".format(my_timeout, request_delay),
+                        "timeout=%ss delay=%ss",
+                        my_timeout,
+                        request_delay,
                     )
                 else:
                     self.config.root_logger.log(
-                        self.config.trace_log_level, "delay={0}s".format(request_delay)
+                        self.config.trace_log_level,
+                        "delay=%ss",
+                        request_delay,
                     )
 
         return results

--- a/fuzzerest/request.py
+++ b/fuzzerest/request.py
@@ -180,26 +180,26 @@ def construct_curl_query(
     if body_obj is not None:
         body = json.dumps(body_obj)
 
-    request = "request = {0}\n".format(method)
+    request = f"request = {method}\n"
 
     if headers_obj is not None:
         for (key, value) in headers_obj.items():
-            headers += 'header = "{0}: {1}"\n'.format(key, value)
+            headers += f'header = "{key}: {value}"\n'
 
     if body_obj is not None:
         body = json.dumps(
             body
         )  # serialize it again, so the data has a proper format in the config file
-        body = "data = {0}\n".format(body)
+        body = f"data = {body}\n"
 
-    url = 'url = "{0}"'.format(url)
+    url = f'url = "{url}"'
 
     Path(os.path.dirname(curl_config_file_path)).mkdir(parents=True, exist_ok=True)
     with open(curl_config_file_path, "w+") as config_file:
         config_file.writelines([request, headers, body, url])
         config_file.close()
 
-    curl_query = "curl -g -K {0}".format(curl_config_file_path)
+    curl_query = f"curl -g -K {curl_config_file_path}"
 
     return curl_query
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -30,9 +30,7 @@ def test_set_logging_level(client):
             argparse_args + ["-l", str(level)]
         )
         client._set_logging_level()
-        msg = "should be log level {0} when level was set to {1}".format(
-            client.config.logging_levels[level], str(level)
-        )
+        msg = f"should be log level {client.config.logging_levels[level]} when level was set to {level}"
         assert (
             client.config.root_logger.level == client.config.logging_levels[level]
         ), msg
@@ -41,9 +39,7 @@ def test_set_logging_level(client):
             argparse_args + ["--loglevel", str(level)]
         )
         client._set_logging_level()
-        msg = "should be log level {0} when level was set to {1}".format(
-            client.config.logging_levels[level], str(level)
-        )
+        msg = f"should be log level {client.config.logging_levels[level]} when level was set to {level}"
         assert (
             client.config.root_logger.level == client.config.logging_levels[level]
         ), msg
@@ -62,7 +58,7 @@ def test_get_cmd_string(client):
     jsonargs = ["-c", '{"my": "test", "json": "arg"}']
     sys.argv = args + jsonargs
     actual = client._get_cmd_string().strip(" ")
-    expected = " ".join(args + [jsonargs[0]]) + " '{0}'".format(jsonargs[1])
+    expected = " ".join(args + [jsonargs[0]]) + f" '{jsonargs[1]}'"
     assert (
         actual == expected
     ), "should reproduce input with json arg surrounded with quotes"
@@ -143,9 +139,9 @@ def test_parse_default_cli_args(client, config):
         script_dir, "..", os.path.realpath(config.example_json_file)
     )
     assert os.path.exists(expected_path), expected_path
-    assert actual_path == expected_path, "actual={}, expected={}".format(
-        actual_path, expected_path
-    )
+    assert (
+        actual_path == expected_path
+    ), f"actual={actual_path}, expected={expected_path}"
     assert client.parsed_args.domain == config.default_model_domain_name
     assert not client.parsed_args.gtimeout, client.parsed_args.gtimeout
     assert client.parsed_args.state == 0

--- a/test/test_fuzzer.py
+++ b/test/test_fuzzer.py
@@ -187,20 +187,20 @@ def inject_constants(fuzzer):
     assert token in json.dumps(fuzzer.model_obj)
     assert token not in json.dumps(
         Fuzzer.inject_constants(fuzzer.model_obj, constants)
-    ), "'{0}' should have been replaced by '{1}'".format(token, constants[token])
+    ), f'"{token}" should have been replaced by "{constants[token]}"'
     assert constants[token] in json.dumps(
         Fuzzer.inject_constants(fuzzer.model_obj, constants)
-    ), ("'{0}' should have replaced '{1}'".format(constants[token], token),)
+    ), f'"{constants[token]}" should have replaced "{token}"'
 
     constants = {token: True}
     assert "true" in json.dumps(
         Fuzzer.inject_constants(fuzzer.model_obj, constants)
-    ), "'{0}' should have replaced '{1}'".format("true", token)
+    ), f'"true" should have replaced "{token}"'
 
     constants = {token: 534897}
     assert str(constants[token]) in json.dumps(
         Fuzzer.inject_constants(fuzzer.model_obj, constants)
-    ), "'{0}' should have replaced '{1}'".format(str(constants[token]), token)
+    ), f'"{constants[token]}" should have replaced "{token}"'
 
 
 def mutate_payload_body(fuzzer):
@@ -340,14 +340,12 @@ def test_iterate_endpoints_uri(config):
     results = fuzzer.iterate_endpoints()
     assert (
         len(results) == expected_n_results
-    ), "should only iterate {0} times over {1} endpoint with all methods".format(
-        str(expected_n_results), fuzzer.uri
-    )
+    ), f"should only iterate {expected_n_results} times over {fuzzer.uri} endpoint with all methods"
 
     for i in results:
-        assert fuzzer.uri in i["url"], "expected iteration {0} to contain {1}".format(
-            json.dumps(i), fuzzer.uri
-        )
+        assert (
+            fuzzer.uri in i["url"]
+        ), f"expected iteration {json.dumps(i)} to contain {fuzzer.uri}"
 
 
 def test_iterate_endpoints_methods(config):
@@ -366,16 +364,12 @@ def test_iterate_endpoints_methods(config):
     results = fuzzer.iterate_endpoints()
     assert (
         len(results) == expected_n_results
-    ), "should only iterate {0} times over all endpoints with methods {1}".format(
-        str(expected_n_results), str(fuzzer.methods)
-    )
+    ), f"should only iterate {expected_n_results} times over all endpoints with methods {fuzzer.methods}"
 
     for i in results:
         assert (
             i["method"] in fuzzer.methods
-        ), "expected iteration {0} to contain one of methods {1}".format(
-            json.dumps(i), str(fuzzer.methods)
-        )
+        ), f"expected iteration {json.dumps(i)} to contain one of methods {fuzzer.methods}"
 
 
 def test_iterate_endpoints_uri_methods(config):
@@ -395,16 +389,12 @@ def test_iterate_endpoints_uri_methods(config):
     results = fuzzer.iterate_endpoints()
     assert (
         len(results) == expected_n_results
-    ), "should only iterate {0} times over all endpoints with methods {1}".format(
-        str(expected_n_results), str(fuzzer.methods)
-    )
+    ), f"should only iterate {expected_n_results} times over all endpoints with methods {fuzzer.methods}"
 
     for i in results:
         assert (
             i["method"] in fuzzer.methods
-        ), "expected iteration {0} to contain one of methods {1}".format(
-            json.dumps(i), str(fuzzer.methods)
-        )
+        ), f"expected iteration {json.dumps(i)} to contain one of methods {fuzzer.methods}"
 
     placeholder = "{otherId}"
     original_uri = "/" + placeholder
@@ -418,8 +408,8 @@ def test_iterate_endpoints_uri_methods(config):
     )
     results = fuzzer.iterate_endpoints()
     assert expected_uri in json.dumps(results), (
-        "should find a request with uri {0} that was changed to {1} after injecting {2} "
-        "as a constant".format(original_uri, expected_uri, expected_constant)
+        f"should find a request with uri {original_uri} that was changed to {expected_uri} after injecting {expected_constant} "
+        "as a constant"
     )
 
     placeholder = "{something_that_doesnt_exist}"
@@ -433,8 +423,8 @@ def test_iterate_endpoints_uri_methods(config):
     )
     results = fuzzer.iterate_endpoints()
     assert expected_uri not in json.dumps(results), (
-        "should not find a request with uri {0} that was changed to {1} after injecting {2} "
-        "as a constant".format(original_uri, expected_uri, expected_constant)
+        f"should not find a request with uri {original_uri} that was changed to {expected_uri} after injecting {expected_constant} "
+        "as a constant"
     )
 
 
@@ -446,9 +436,7 @@ def test_iterate_endpoints_all(config):
     results = fuzzer.iterate_endpoints()
     assert (
         len(results) == expected_n_results
-    ), "should only iterate {0} times over all endpoints and methods".format(
-        str(expected_n_results)
-    )
+    ), f"should only iterate {expected_n_results} times over all endpoints and methods"
 
 
 def test_iterate_endpoints_log_summary_uri(config):
@@ -499,9 +487,7 @@ def test_check_for_model_update(fuzzer):
     fuzzer._check_for_model_update()
     assert (
         model == fuzzer.model_obj
-    ), "should not change since elapsed time ({0}s) has not exceeded reload interval ({1}s)".format(
-        fuzzer.time_since_last_model_check, fuzzer.model_reload_rate
-    )
+    ), f"should not change since elapsed time ({fuzzer.time_since_last_model_check}s) has not exceeded reload interval ({fuzzer.model_reload_rate}s)"
 
     fuzzer.time_since_last_model_check = fuzzer.model_reload_rate + 1
     fuzzer._check_for_model_update()
@@ -635,26 +621,20 @@ def test_state_iteration(config):
     for r in results:
         assert (
             int(r["headers"]["X-fuzzeREST-State"]) == state
-        ), "state for each endpoint should be {0} for the first iteration".format(
-            str(state)
-        )
+        ), f"state for each endpoint should be {state} for the first iteration"
 
     state += 1
     results = fuzzer.fuzz_requests_by_incremental_state(n_times)
     for r in results:
         assert (
             int(r["headers"]["X-fuzzeREST-State"]) == state
-        ), "state for each endpoint should be {0} for the second iteration".format(
-            str(state)
-        )
+        ), f"state for each endpoint should be {state} for the second iteration"
 
     results = fuzzer.fuzz_requests_by_incremental_state(n_times)
     for r in results:
         assert (
             int(r["headers"]["X-fuzzeREST-State"]) != state
-        ), "state for each endpoint should be {0} for the third iteration".format(
-            str(state + 1)
-        )
+        ), f"state for each endpoint should be {state + 1} for the third iteration"
 
 
 def test_get_states_from_file(config):
@@ -679,9 +659,7 @@ def test_send_delayed_request_local(config):
     expected_delay = request.get_request_delay(expected_requests_per_second)
     assert (
         results[0]["delay"] == expected_delay
-    ), "local request rate defined in endpoint should have delay of {0}".format(
-        expected_delay
-    )
+    ), f"local request rate defined in endpoint should have delay of {expected_delay}"
 
 
 def test_send_delayed_request_global(config):
@@ -699,9 +677,7 @@ def test_send_delayed_request_global(config):
     expected_delay = request.get_request_delay(expected_requests_per_second)
     assert (
         results[0]["delay"] == expected_delay
-    ), "local request rate should override global definition with delay of {0}".format(
-        expected_delay
-    )
+    ), f"local request rate should override global definition with delay of {expected_delay}"
 
     fuzzer = Fuzzer(
         config.example_json_file,
@@ -715,7 +691,7 @@ def test_send_delayed_request_global(config):
     expected_delay = request.get_request_delay(fuzzer.model_obj["requestsPerSecond"])
     assert (
         results[0]["delay"] == expected_delay
-    ), "global definition should have delay of {0}".format(expected_delay)
+    ), f"global definition should have delay of {expected_delay}"
 
 
 def test_get_curl_query_string(fuzzer):

--- a/test/test_mutator.py
+++ b/test/test_mutator.py
@@ -22,9 +22,7 @@ def test_chance(mutator):
     diff = abs(result[True] / n_times - expected_probability)
     assert (
         tolerance >= diff
-    ), "{0} exceeded tolerance of {1} for probability {2}".format(
-        diff, tolerance, expected_probability
-    )
+    ), f"{diff} exceeded tolerance of {tolerance} for probability {expected_probability}"
 
 
 def test_chance_identity(mutator):
@@ -51,9 +49,7 @@ def test_roll_dice(mutator):
         diff = abs(result[n] / n_times - expected_probability)
         assert (
             tolerance >= diff
-        ), "{0} exceeded tolerance of {1} for probability {2}".format(
-            diff, tolerance, expected_probability
-        )
+        ), f"{diff} exceeded tolerance of {tolerance} for probability {expected_probability}"
 
 
 def test_roll_dice_identity(mutator):
@@ -80,9 +76,7 @@ def test_juggle_type(mutator):
         diff = abs(result[key] / n_times - expected_probability)
         assert (
             tolerance >= diff
-        ), "{0} exceeded tolerance of {1} for probability {2}".format(
-            diff, tolerance, expected_probability
-        )
+        ), f"{diff} exceeded tolerance of {tolerance} for probability {expected_probability}"
 
 
 def test_mutate_radamsa_state_change(mutator):
@@ -320,12 +314,8 @@ def test_safe_decode(mutator):
     emoji = "🙂"
     assert mutator.safe_decode(emoji.encode()) == emoji.encode().decode(
         mutator.byte_encoding
-    ), "should properly decode '{0}' using {1} encoding".format(
-        emoji, mutator.byte_encoding
-    )
+    ), f'should properly decode "{emoji}" using {mutator.byte_encoding} encoding'
     mutator.byte_encoding = "ascii"
     assert mutator.safe_decode(emoji.encode()) == str(
         emoji.encode()
-    ), "should stringify '{0}' bytes because it cannot decode using {1} byte encoding".format(
-        emoji, mutator.byte_encoding
-    )
+    ), f'should stringify "{emoji}" bytes because it cannot decode using {mutator.byte_encoding} byte encoding'

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -51,7 +51,7 @@ def test_get_endpoints(model):
     endpoints = Fuzzer.get_endpoints(model["endpoints"], uri)
     assert (
         len(endpoints) == nExpected
-    ), "should have {0} endpoint definitions for {1}".format(nExpected, uri)
+    ), f"should have {nExpected} endpoint definitions for {uri}"
 
     methods = ["PUT", "PATCH"]
     nExpected = 1
@@ -103,7 +103,7 @@ def test_construct_curl_query(config, model):
         endpoint["input"]["query"],
     )
 
-    expected_query = "curl -g -K {0}".format(curl_data_file_path)
+    expected_query = f"curl -g -K {curl_data_file_path}"
 
     assert expected_query == actual_query, "should construct a valid curl query"
 


### PR DESCRIPTION
Notes
- f-strings were used in place of `.format()`, except for logging statements (see [here](https://blog.pilosus.org/posts/2020/01/24/python-f-strings-in-logging/) for details on reasoning)
- `.format()` was kept for large formatting operations, such as itemizing ditct elements